### PR TITLE
fix: set default avatar when avatar is not present

### DIFF
--- a/src/Controllers/DiscordAuthController.php
+++ b/src/Controllers/DiscordAuthController.php
@@ -79,6 +79,6 @@ class DiscordAuthController extends AbstractOAuthController
     {
         $hash = $user->getAvatarHash();
 
-        return isset($hash) ? "https://cdn.discordapp.com/avatars/{$user->getId()}/{$user->getAvatarHash()}.png" : '';
+        return isset($hash) ? "https://cdn.discordapp.com/avatars/{$user->getId()}/{$user->getAvatarHash()}.png" : "https://cdn.discordapp.com/embed/avatars/0.png";
     }
 }


### PR DESCRIPTION
```
[2019-07-14 10:21:56] production.ERROR: Intervention\Image\Exception\NotReadableException: Unable to init from given binary data.
in /home/pi/flarum/vendor/intervention/image/src/Intervention/Image/Gd/Decoder.php:115
Stack trace:
#0 /home/pi/flarum/vendor/intervention/image/src/Intervention/Image/AbstractDecoder.php(343): Intervention\Image\Gd\Decoder->initFromBinary('')
#1 /home/pi/flarum/vendor/intervention/image/src/Intervention/Image/AbstractDriver.php(66): Intervention\Image\AbstractDecoder->init('')
#2 /home/pi/flarum/vendor/intervention/image/src/Intervention/Image/ImageManager.php(54): Intervention\Image\AbstractDriver->init('')
#3 /home/pi/flarum/vendor/flarum/core/src/User/Command/RegisterUserHandler.php(141): Intervention\Image\ImageManager->make('')
#4 /home/pi/flarum/vendor/flarum/core/src/User/Command/RegisterUserHandler.php(123): Flarum\User\Command\RegisterUserHandler->uploadAvatarFromUrl(Object(Flarum\User\User), '')
```

This is error I got.

### How to reproduce
1. Create new discord account that not set avatar
2. Create new account in Flarum through this auth-discord ext.
3. Produce this error.